### PR TITLE
Fix compile error: include cstdint

### DIFF
--- a/source/DefDocument.h
+++ b/source/DefDocument.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 #include <algorithm>
+#include <cstdint>
 
 template <typename U, typename V>
 struct TrivialPair


### PR DESCRIPTION
Fails on modern compilers (c++ (GCC) 15.1.1 20250425):
```
[5/16] Compiling C++ object dekodef.p/source_DefBackendMme.cpp.o
FAILED: dekodef.p/source_DefBackendMme.cpp.o
ccache c++ -Idekodef.p -I. -I.. -Isource -I../source -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++14 -O3 '-DPACKAGE_STRING="dekotools 1.0.0"' -MD -MQ dekodef.p/source_DefBackendMme.cpp.o -MF dekodef.p/source_DefBackendMme.cpp.o.d -o dekodef.p/source_DefBackendMme.cpp.o -c ../source/DefBackendMme.cpp
In file included from ../source/DefBackendMme.cpp:5:
../source/DefDocument.h:22:9: error: ‘uint32_t’ does not name a type
   22 |         uint32_t m_engineClass;
      |         ^~~~~~~~
../source/DefDocument.h:9:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    8 | #include <algorithm>
  +++ |+#include <cstdint>
```